### PR TITLE
Fix up the WIFI connection dialogs, plus some misc GUI fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+Makefile
+*.o
+moc*.cpp
+ui_*.h
+qrc_*.cpp
+pc-*

--- a/src/NetworkManager/networkman.cpp
+++ b/src/NetworkManager/networkman.cpp
@@ -155,12 +155,12 @@ void NetworkMan::detectDev()
 
                 // Place a message box prompt here
                 QMessageBox msgBox;
-                msgBox.setText("A new wireless device (" + dev + ") has been detected.");
-	        msgBox.setInformativeText("Do you want to enable this device now?");
- 	        msgBox.setStandardButtons(QMessageBox::No | QMessageBox::Yes);
-    	        msgBox.setDefaultButton(QMessageBox::Yes);
- 	        int ret = msgBox.exec();
-                if ( ret == QMessageBox::Yes )
+                msgBox.setText(tr("A new wireless device (%1) has been detected.").arg(dev));
+	        msgBox.setInformativeText(tr("Do you want to enable this device now?"));
+                auto enableButton = msgBox.addButton(tr("Enable"), QMessageBox::AcceptRole);
+                msgBox.addButton(QMessageBox::Cancel);
+ 	        msgBox.exec();
+                if ( msgBox.clickedButton() == enableButton )
                 {
                   // Get the next available wlan[0-9] device
                   tmp = getNextAvailWlan();

--- a/src/wificonfig/dialogwpaenterprise.cpp
+++ b/src/wificonfig/dialogwpaenterprise.cpp
@@ -1,0 +1,173 @@
+/****************************************************************************
+** ui.h extension file, included from the uic-generated form implementation.
+**
+** If you want to add, delete, or rename functions or slots, use
+** Qt Designer to update this file, preserving your code.
+**
+** You should not define a constructor or destructor in this file.
+** Instead, write your code in functions called init() and destroy().
+** These will automatically be called by the form's constructor and
+** destructor.
+*****************************************************************************/
+#include "dialogwpaenterprise.h"
+#include "ui_dialogwpaenterprise.h"
+#include <qfiledialog.h>
+
+void dialogWPAEnterprise::init()
+{
+    if ( radioEAPTLS->isChecked() ) {
+	textPhase2->setHidden(true);
+	comboPhase2->setHidden(true);
+	textAnonIdentity->setHidden(true);
+	lineAnonIdentity->setHidden(true);
+    }
+}
+
+void dialogWPAEnterprise::on_buttonBox_clicked(QAbstractButton *button)
+{
+    if (buttonBox->standardButton(button) == QDialogButtonBox::Ok) {
+        saveAndClose();
+    } else { // the cancel button
+        close();
+    }
+}
+
+void dialogWPAEnterprise::slotTypeChanged()
+{
+    
+    if ( radioEAPTLS->isChecked() ) {
+	textClientCert->setHidden(false);
+	lineClientCert->setHidden(false);
+	pushSelectClientCert->setHidden(false);
+	textPrivateKeyFile->setHidden(false);
+	linePrivateKeyFile->setHidden(false);
+	pushSelectPrivateKeyFile->setHidden(false);	
+	textPhase2->setHidden(true);
+	comboPhase2->setHidden(true);
+	textAnonIdentity->setHidden(true);
+	lineAnonIdentity->setHidden(true);
+    }
+    
+    if ( radioEAPTTLS->isChecked() ) {
+	textClientCert->setHidden(true);
+	lineClientCert->setHidden(true);
+	pushSelectClientCert->setHidden(true);
+	textPrivateKeyFile->setHidden(true);
+	linePrivateKeyFile->setHidden(true);
+	pushSelectPrivateKeyFile->setHidden(true);	
+	textPhase2->setHidden(false);
+	comboPhase2->setHidden(false);
+    textAnonIdentity->setHidden(false);
+    lineAnonIdentity->setHidden(false);
+    }
+    
+    if ( radioEAPPEAP->isChecked() ) {
+	textClientCert->setHidden(true);
+	lineClientCert->setHidden(true);
+	pushSelectClientCert->setHidden(true);
+	textPrivateKeyFile->setHidden(true);
+	linePrivateKeyFile->setHidden(true);
+	pushSelectPrivateKeyFile->setHidden(true);
+	textPhase2->setHidden(false);
+	comboPhase2->setHidden(false);
+    textAnonIdentity->setHidden(false);
+    lineAnonIdentity->setHidden(false);
+    }
+
+}
+
+
+void dialogWPAEnterprise::saveAndClose()
+{
+    int type = 0;
+    
+    if ( radioEAPTLS->isChecked() )
+    {
+	type = 1;
+    }
+    
+    if ( radioEAPTTLS->isChecked() )
+    {
+	type = 2;
+    }	
+    
+    if ( radioEAPPEAP->isChecked() )
+    {
+	type = 3;
+    }
+
+    emit saved( type, lineEAPIdentity->text(), lineAnonIdentity->text(), lineCACert->text(), lineClientCert->text(), linePrivateKeyFile->text(), linePrivateKeyPassword->text(), comboKeyMgmt->currentIndex(), comboPhase2->currentIndex() );
+    close();
+}
+
+
+void dialogWPAEnterprise::slotSelectCACert()
+{
+        QString file = QFileDialog::getOpenFileName( 0, 
+                    "Choose a Certificate file",
+                    "/home",
+                    "Certificate File (*)" );
+	
+	lineCACert->setText(file);
+	
+}
+
+
+void dialogWPAEnterprise::slotSelectClientCert()
+{
+       QString file = QFileDialog::getOpenFileName( 0,
+                    "Choose a client certificate file",
+                    "/home",
+                    "Certificate File (*)" );
+	
+	lineClientCert->setText(file);
+}
+
+
+void dialogWPAEnterprise::slotSelectPrivateKeyFile()
+{
+       QString file = QFileDialog::getOpenFileName( 0,
+                    "Choose a private key file",
+                    "/home",
+                    "Certificate File (*)");
+	
+	linePrivateKeyFile->setText(file);
+}
+
+
+void dialogWPAEnterprise::setVariables( int type, QString EAPIdent, QString AnonIdent, QString CACert, QString ClientCert, QString PrivKeyFile, QString Password, int keyMgmt, int EAPPhase2 )
+{
+    // Load the existing settings for this configuration
+    
+    if ( type == 1)
+    {
+	radioEAPTLS->setChecked(true);
+    } else if (type == 2) {
+	radioEAPTTLS->setChecked(true);
+    } else if (type == 3) {
+	radioEAPPEAP->setChecked(true);
+    }
+
+    comboKeyMgmt->setCurrentIndex(keyMgmt);
+    comboPhase2->setCurrentIndex(EAPPhase2);
+
+    lineEAPIdentity->setText(EAPIdent);
+    lineAnonIdentity->setText(AnonIdent);
+    lineCACert->setText(CACert);
+    lineClientCert->setText(ClientCert);
+    linePrivateKeyFile->setText(PrivKeyFile);
+    linePrivateKeyPassword->setText(Password);
+    
+    slotTypeChanged();
+    
+}
+
+void dialogWPAEnterprise::on_checkShowKey_clicked(bool checked)
+{
+   if(checked)
+   {
+      linePrivateKeyPassword->setEchoMode(QLineEdit::Normal);
+   } else {
+      linePrivateKeyPassword->setEchoMode(QLineEdit::Password);
+   }
+}

--- a/src/wificonfig/dialogwpaenterprise.h
+++ b/src/wificonfig/dialogwpaenterprise.h
@@ -1,0 +1,51 @@
+#ifndef DIALOGWPAENTERPRISE_H
+#define DIALOGWPAENTERPRISE_H
+
+#include <QDebug>
+#include <QDialog>
+#include <QFile>
+#include <QMessageBox>
+#include <QTranslator>
+#include "ui_dialogwpaenterprise.h"
+
+class dialogWPAEnterprise : public QDialog, private Ui::dialogWPAEnterprise
+{
+        Q_OBJECT
+
+public:
+        dialogWPAEnterprise() : QDialog()
+        {
+          QTranslator translator;
+          QLocale mylocale;
+          QString langCode = mylocale.name();
+          if ( ! QFile::exists( "/usr/local/share/lifePreserver/i18n/libtrueos_" + langCode + ".qm" ) )
+            langCode.truncate(langCode.indexOf("_"));
+          translator.load( QString("libtrueos_") + langCode, "/usr/local/share/lifePreserver/i18n/" );
+          QCoreApplication::installTranslator( &translator );
+          qDebug() << "Locale:" << langCode;
+          setupUi(this);
+	  setWindowModality(Qt::ApplicationModal);
+        }
+
+    void setVariables( int type, QString EAPIdent, QString AnonIdent, QString CACert, QString ClientCert, QString PrivKeyFile, QString Password, int keyMgmt, int EAPPhase2 );
+    void init();
+
+public slots:
+
+private slots:
+    void slotTypeChanged();
+    void slotSelectCACert();
+    void slotSelectClientCert();
+    void slotSelectPrivateKeyFile();
+    void on_checkShowKey_clicked(bool checked);
+    void on_buttonBox_clicked(QAbstractButton *);
+    void saveAndClose();
+
+private:
+
+signals:
+  void saved(int, QString, QString, QString, QString, QString, QString, int, int);
+
+} ;
+#endif // DIALOGWPAENTERPRISE_H
+

--- a/src/wificonfig/dialogwpaenterprise.ui
+++ b/src/wificonfig/dialogwpaenterprise.ui
@@ -1,0 +1,437 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>dialogWPAEnterprise</class>
+ <widget class="QDialog" name="dialogWPAEnterprise">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>468</width>
+    <height>573</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>WPA-Enterprise Configuration</string>
+  </property>
+  <property name="windowIcon">
+   <iconset resource="wificonfig.qrc">
+    <normaloff>:/tray_wifi85.png</normaloff>:/tray_wifi85.png</iconset>
+  </property>
+  <layout class="QGridLayout" name="gridLayout_2">
+   <item row="1" column="0">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>WPA Enterprise Configuration</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="6" column="2">
+       <widget class="QPushButton" name="pushSelectCACert">
+        <property name="text">
+         <string/>
+        </property>
+        <property name="icon">
+         <iconset resource="wificonfig.qrc">
+          <normaloff>:/folder_open.png</normaloff>:/folder_open.png</iconset>
+        </property>
+       </widget>
+      </item>
+      <item row="11" column="0">
+       <widget class="QLabel" name="textPrivateKey">
+        <property name="text">
+         <string>Password:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+        <property name="wordWrap">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="13" column="0" colspan="2">
+       <spacer name="verticalSpacer">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="3" column="1">
+       <widget class="QComboBox" name="comboKeyMgmt">
+        <item>
+         <property name="text">
+          <string notr="true">WPA-EAP</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string notr="true">IEE8021X</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="3" column="0" alignment="Qt::AlignRight">
+       <widget class="QLabel" name="labelKeyMgmt">
+        <property name="text">
+         <string>Key Management</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="2">
+       <widget class="QPushButton" name="pushSelectPrivateKeyFile">
+        <property name="text">
+         <string/>
+        </property>
+        <property name="icon">
+         <iconset resource="wificonfig.qrc">
+          <normaloff>:/folder_open.png</normaloff>:/folder_open.png</iconset>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1" colspan="2">
+       <widget class="QLineEdit" name="lineEAPIdentity"/>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="textLabel2">
+        <property name="text">
+         <string>EAP Identity:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+        <property name="wordWrap">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0" colspan="2">
+       <layout class="QHBoxLayout">
+        <item>
+         <widget class="QRadioButton" name="radioEAPTLS">
+          <property name="text">
+           <string>EAP-TLS</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QRadioButton" name="radioEAPTTLS">
+          <property name="text">
+           <string>EAP-TTLS</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QRadioButton" name="radioEAPPEAP">
+          <property name="text">
+           <string>EAP-PEAP</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="0" column="0" colspan="2">
+       <widget class="QLabel" name="textLabel1">
+        <property name="text">
+         <string>EAP authentication method</string>
+        </property>
+        <property name="wordWrap">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="1">
+       <widget class="QLineEdit" name="lineClientCert">
+        <property name="readOnly">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="0">
+       <widget class="QLabel" name="textCACert">
+        <property name="text">
+         <string>CA Certificate:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+        <property name="wordWrap">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="0">
+       <widget class="QLabel" name="textPrivateKeyFile">
+        <property name="text">
+         <string>Private Key File:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+        <property name="wordWrap">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="1">
+       <widget class="QLineEdit" name="lineCACert">
+        <property name="readOnly">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="0">
+       <widget class="QLabel" name="textClientCert">
+        <property name="text">
+         <string>Client Certificate:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+        <property name="wordWrap">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="2">
+       <widget class="QPushButton" name="pushSelectClientCert">
+        <property name="text">
+         <string/>
+        </property>
+        <property name="icon">
+         <iconset resource="wificonfig.qrc">
+          <normaloff>:/folder_open.png</normaloff>:/folder_open.png</iconset>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="1">
+       <widget class="QLineEdit" name="linePrivateKeyFile">
+        <property name="readOnly">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="10" column="0" alignment="Qt::AlignRight">
+       <widget class="QLabel" name="textPhase2">
+        <property name="inputMethodHints">
+         <set>Qt::ImhNone</set>
+        </property>
+        <property name="text">
+         <string>Phase 2 Auth:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="12" column="0">
+       <widget class="QCheckBox" name="checkShowKey">
+        <property name="text">
+         <string>Show Key</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="1" colspan="2">
+       <widget class="QLineEdit" name="lineAnonIdentity"/>
+      </item>
+      <item row="5" column="0">
+       <widget class="QLabel" name="textAnonIdentity">
+        <property name="text">
+         <string>Anonymous Identity:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="11" column="1" colspan="2">
+       <widget class="QLineEdit" name="linePrivateKeyPassword">
+        <property name="echoMode">
+         <enum>QLineEdit::Password</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="10" column="1" colspan="2">
+       <widget class="QComboBox" name="comboPhase2">
+        <property name="inputMethodHints">
+         <set>Qt::ImhNone</set>
+        </property>
+        <item>
+         <property name="text">
+          <string>MD5</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>MSCHAPV2</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>GTC</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>OTP</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>PAP</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>CHAP</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>MSCHAP</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <layoutdefault spacing="6" margin="11"/>
+ <tabstops>
+  <tabstop>radioEAPTLS</tabstop>
+  <tabstop>radioEAPTTLS</tabstop>
+  <tabstop>radioEAPPEAP</tabstop>
+  <tabstop>comboKeyMgmt</tabstop>
+  <tabstop>lineEAPIdentity</tabstop>
+  <tabstop>lineAnonIdentity</tabstop>
+  <tabstop>lineCACert</tabstop>
+  <tabstop>pushSelectCACert</tabstop>
+  <tabstop>lineClientCert</tabstop>
+  <tabstop>pushSelectClientCert</tabstop>
+  <tabstop>linePrivateKeyFile</tabstop>
+  <tabstop>pushSelectPrivateKeyFile</tabstop>
+  <tabstop>comboPhase2</tabstop>
+  <tabstop>linePrivateKeyPassword</tabstop>
+  <tabstop>checkShowKey</tabstop>
+ </tabstops>
+ <includes>
+  <include location="local">qmessagebox.h</include>
+ </includes>
+ <resources>
+  <include location="wificonfig.qrc"/>
+ </resources>
+ <connections>
+  <connection>
+   <sender>radioEAPTLS</sender>
+   <signal>clicked()</signal>
+   <receiver>dialogWPAEnterprise</receiver>
+   <slot>slotTypeChanged()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>radioEAPTTLS</sender>
+   <signal>clicked()</signal>
+   <receiver>dialogWPAEnterprise</receiver>
+   <slot>slotTypeChanged()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>radioEAPPEAP</sender>
+   <signal>clicked()</signal>
+   <receiver>dialogWPAEnterprise</receiver>
+   <slot>slotTypeChanged()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>pushSelectCACert</sender>
+   <signal>clicked()</signal>
+   <receiver>dialogWPAEnterprise</receiver>
+   <slot>slotSelectCACert()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>pushSelectClientCert</sender>
+   <signal>clicked()</signal>
+   <receiver>dialogWPAEnterprise</receiver>
+   <slot>slotSelectClientCert()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>pushSelectPrivateKeyFile</sender>
+   <signal>clicked()</signal>
+   <receiver>dialogWPAEnterprise</receiver>
+   <slot>slotSelectPrivateKeyFile()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/wificonfig/dialogwpapersonal.cpp
+++ b/src/wificonfig/dialogwpapersonal.cpp
@@ -11,41 +11,39 @@
 *****************************************************************************/
 #include "dialogwpapersonal.h"
 #include "ui_dialogwpapersonal.h"
+#include <QDialogButtonBox>
 
 
 void dialogWPAPersonal::setKey( QString Key )
 {
     lineKey->setText(Key);
-    lineKey2->setText(Key);
 }
 
-
-void dialogWPAPersonal::slotClose()
+void dialogWPAPersonal::on_buttonBox_clicked(QAbstractButton *button)
 {
-  if ( lineKey->text() != lineKey2->text() )
-  {
-     QMessageBox::warning( this, "Network Key Error", "Error: The entered network keys do not match!\n" );
-     return;
-  } 
-  
-  if ( lineKey->text().length() < 8 || lineKey->text().length() > 63 )
-  {
+    if (buttonBox->standardButton(button) == QDialogButtonBox::Ok) {
+        saveAndClose();
+    } else { // the cancel button
+        close();
+    }
+}
+
+void dialogWPAPersonal::saveAndClose()
+{
+  if ( lineKey->text().length() < 8 || lineKey->text().length() > 63 ) {
      QMessageBox::warning( this, "Network Key Error", "Error: The network key must be between 8-63 characters in length!\n" );
      return;
-  } 
+  }
 
   emit saved(lineKey->text());
   close();
 }
 
-void dialogWPAPersonal::slotShowKey()
+void dialogWPAPersonal::on_checkShowKey_clicked(bool checked)
 {
-   if(checkShowKey->isChecked())
-   {
-      lineKey2->setEchoMode(QLineEdit::Normal);
+   if(checked) {
       lineKey->setEchoMode(QLineEdit::Normal);
    } else {
-      lineKey2->setEchoMode(QLineEdit::Password);
       lineKey->setEchoMode(QLineEdit::Password);
    }
 }

--- a/src/wificonfig/dialogwpapersonal.h
+++ b/src/wificonfig/dialogwpapersonal.h
@@ -21,8 +21,9 @@ public:
 public slots:
 
 private slots:
-    void slotClose();
-    void slotShowKey();
+    void on_buttonBox_clicked(QAbstractButton *);
+    void saveAndClose();
+    void on_checkShowKey_clicked(bool checked);
 
 private:
 

--- a/src/wificonfig/dialogwpapersonal.ui
+++ b/src/wificonfig/dialogwpapersonal.ui
@@ -1,77 +1,62 @@
-<ui version="4.0" >
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
  <class>dialogWPAPersonal</class>
- <widget class="QDialog" name="dialogWPAPersonal" >
-  <property name="geometry" >
+ <widget class="QDialog" name="dialogWPAPersonal">
+  <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>311</width>
-    <height>168</height>
+    <width>469</width>
+    <height>200</height>
    </rect>
   </property>
-  <property name="windowTitle" >
+  <property name="windowTitle">
    <string>WPA Personal Config</string>
   </property>
-  <property name="windowIcon" >
-   <iconset resource="wificonfig.qrc" >
+  <property name="windowIcon">
+   <iconset resource="wificonfig.qrc">
     <normaloff>:/tray_wifi85.png</normaloff>:/tray_wifi85.png</iconset>
   </property>
-  <layout class="QGridLayout" name="gridLayout_2" >
-   <item row="0" column="0" >
-    <widget class="QGroupBox" name="groupBox" >
-     <property name="title" >
+  <layout class="QGridLayout" name="gridLayout_2">
+   <item row="1" column="0">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
       <string>WPA Personal Configuration</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout" >
-      <item row="0" column="0" >
-       <widget class="QLabel" name="textLabel1" >
-        <property name="text" >
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="0" column="0">
+       <widget class="QLabel" name="textLabel1">
+        <property name="text">
          <string>Network Key</string>
         </property>
-        <property name="wordWrap" >
+        <property name="wordWrap">
          <bool>false</bool>
         </property>
        </widget>
       </item>
-      <item row="0" column="1" >
-       <widget class="QLineEdit" name="lineKey" >
-        <property name="minimumSize" >
+      <item row="0" column="1">
+       <widget class="QLineEdit" name="lineKey">
+        <property name="minimumSize">
          <size>
           <width>150</width>
           <height>0</height>
          </size>
         </property>
-        <property name="echoMode" >
+        <property name="echoMode">
          <enum>QLineEdit::Password</enum>
         </property>
        </widget>
       </item>
-      <item row="1" column="0" >
-       <widget class="QLabel" name="textLabel1_2" >
-        <property name="text" >
-         <string>Network Key (Repeat)</string>
-        </property>
-        <property name="wordWrap" >
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1" >
-       <widget class="QLineEdit" name="lineKey2" >
-        <property name="minimumSize" >
-         <size>
-          <width>150</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="echoMode" >
-         <enum>QLineEdit::Password</enum>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0" colspan="2" >
-       <widget class="QCheckBox" name="checkShowKey" >
-        <property name="text" >
+      <item row="1" column="0" colspan="2">
+       <widget class="QCheckBox" name="checkShowKey">
+        <property name="text">
          <string>Show Key</string>
         </property>
        </widget>
@@ -79,77 +64,14 @@
      </layout>
     </widget>
    </item>
-   <item row="1" column="0" >
-    <layout class="QHBoxLayout" name="horizontalLayout" >
-     <item>
-      <spacer name="spacer12" >
-       <property name="orientation" >
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeType" >
-        <enum>QSizePolicy::Expanding</enum>
-       </property>
-       <property name="sizeHint" stdset="0" >
-        <size>
-         <width>191</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QPushButton" name="pushClose" >
-       <property name="text" >
-        <string>&amp;Close</string>
-       </property>
-       <property name="shortcut" >
-        <string>Alt+C</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
   </layout>
  </widget>
- <layoutdefault spacing="6" margin="11" />
+ <layoutdefault spacing="6" margin="11"/>
  <includes>
-  <include location="local" >qmessagebox.h</include>
+  <include location="local">qmessagebox.h</include>
  </includes>
  <resources>
-  <include location="wificonfig.qrc" />
+  <include location="wificonfig.qrc"/>
  </resources>
- <connections>
-  <connection>
-   <sender>pushClose</sender>
-   <signal>clicked()</signal>
-   <receiver>dialogWPAPersonal</receiver>
-   <slot>slotClose()</slot>
-   <hints>
-    <hint type="sourcelabel" >
-     <x>20</x>
-     <y>20</y>
-    </hint>
-    <hint type="destinationlabel" >
-     <x>20</x>
-     <y>20</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>checkShowKey</sender>
-   <signal>clicked()</signal>
-   <receiver>dialogWPAPersonal</receiver>
-   <slot>slotShowKey()</slot>
-   <hints>
-    <hint type="sourcelabel" >
-     <x>129</x>
-     <y>85</y>
-    </hint>
-    <hint type="destinationlabel" >
-     <x>129</x>
-     <y>73</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>

--- a/src/wificonfig/wepconfig.cpp
+++ b/src/wificonfig/wepconfig.cpp
@@ -11,8 +11,17 @@
 *****************************************************************************/
 #include "wepconfig.h"
 #include "ui_wepconfig.h"
+#include <QDialogButtonBox>
 
 
+void wepConfig::on_buttonBox_clicked(QAbstractButton *button)
+{
+    if (buttonBox->standardButton(button) == QDialogButtonBox::Ok) {
+        saveAndClose();
+    } else { // the cancel button
+        close();
+    }
+}
 
 void wepConfig::setKey( QString Key, int index, bool wephex )
 {
@@ -20,7 +29,6 @@ void wepConfig::setKey( QString Key, int index, bool wephex )
     if ( ! Key.isEmpty() )
     {
 	lineKey->setText(Key);
-	lineKey2->setText(Key);
     }
  
     // Set if we are using plaintext or a hex key
@@ -41,7 +49,7 @@ void wepConfig::setKey( QString Key, int index, bool wephex )
 }
 
 
-void wepConfig::slotClose()
+void wepConfig::saveAndClose()
 {
     //bool ok;
     //lineKey->text().toInt(&ok, 16);
@@ -52,29 +60,20 @@ void wepConfig::slotClose()
     //   QMessageBox::warning( this, tr("Hex Key"), tr("Error: The specified key is not a valid hex key.") );
     //   return;
     //}
-    
 
-    if ( lineKey->text() != lineKey2->text() )
-    {
-	QMessageBox::warning( this, "Network Key Error", "Error: The entered network keys do not match!\n" );
+    if ( radioHex->isChecked() ) {
+        emit saved(lineKey->text(), spinIndex->value(), true);
     } else {
-	if ( radioHex->isChecked() ) {
-  	  emit saved(lineKey->text(), spinIndex->value(), true);
-        } else {
-          emit saved(lineKey->text(), spinIndex->value(), false);
-        }
-	close();
+        emit saved(lineKey->text(), spinIndex->value(), false);
     }
+    close();
 }
 
-void wepConfig::slotShowKey()
+void wepConfig::on_checkShowKey_clicked(bool checked)
 {
-   if(checkShowKey->isChecked())
-   {
-      lineKey2->setEchoMode(QLineEdit::Normal);
+   if(checked) {
       lineKey->setEchoMode(QLineEdit::Normal);
    } else {
-      lineKey2->setEchoMode(QLineEdit::Password);
       lineKey->setEchoMode(QLineEdit::Password);
    }
 }

--- a/src/wificonfig/wepconfig.h
+++ b/src/wificonfig/wepconfig.h
@@ -24,8 +24,9 @@ public:
 public slots:
 
 private slots:
-   void slotClose();
-   void slotShowKey();
+   void on_buttonBox_clicked(QAbstractButton *);
+   void saveAndClose();
+   void on_checkShowKey_clicked(bool checked);
 
 private:
 

--- a/src/wificonfig/wepconfig.ui
+++ b/src/wificonfig/wepconfig.ui
@@ -1,108 +1,92 @@
-<ui version="4.0" >
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
  <class>wepConfig</class>
- <widget class="QDialog" name="wepConfig" >
-  <property name="geometry" >
+ <widget class="QDialog" name="wepConfig">
+  <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>337</width>
-    <height>224</height>
+    <width>374</width>
+    <height>285</height>
    </rect>
   </property>
-  <property name="windowTitle" >
+  <property name="windowTitle">
    <string>WEP Configuration</string>
   </property>
-  <property name="windowIcon" >
-   <iconset resource="wificonfig.qrc" >
+  <property name="windowIcon">
+   <iconset resource="wificonfig.qrc">
     <normaloff>:/tray_wifi85.png</normaloff>:/tray_wifi85.png</iconset>
   </property>
-  <layout class="QGridLayout" name="gridLayout_2" >
-   <item row="0" column="0" >
-    <widget class="QGroupBox" name="groupBox" >
-     <property name="title" >
+  <layout class="QGridLayout" name="gridLayout_2">
+   <item row="0" column="0">
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
       <string>Wireless Network Key</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout" >
-      <item row="0" column="0" colspan="3" >
-       <widget class="QRadioButton" name="radioHex" >
-        <property name="text" >
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="0" column="0" colspan="3">
+       <widget class="QRadioButton" name="radioHex">
+        <property name="text">
          <string>Hex Key</string>
         </property>
-        <property name="checked" >
+        <property name="checked">
          <bool>true</bool>
         </property>
        </widget>
       </item>
-      <item row="0" column="3" colspan="2" >
-       <widget class="QRadioButton" name="radioPlaintext" >
-        <property name="text" >
+      <item row="0" column="3" colspan="2">
+       <widget class="QRadioButton" name="radioPlaintext">
+        <property name="text">
          <string>Plaintext</string>
         </property>
        </widget>
       </item>
-      <item row="1" column="0" colspan="2" >
-       <widget class="QLabel" name="textLabel1" >
-        <property name="text" >
+      <item row="1" column="0" colspan="2">
+       <widget class="QLabel" name="textLabel1">
+        <property name="text">
          <string>Network Key</string>
         </property>
-        <property name="wordWrap" >
+        <property name="wordWrap">
          <bool>false</bool>
         </property>
        </widget>
       </item>
-      <item row="1" column="2" colspan="3" >
-       <widget class="QLineEdit" name="lineKey" >
-        <property name="echoMode" >
+      <item row="1" column="2" colspan="3">
+       <widget class="QLineEdit" name="lineKey">
+        <property name="echoMode">
          <enum>QLineEdit::Password</enum>
         </property>
        </widget>
       </item>
-      <item row="2" column="0" colspan="2" >
-       <widget class="QLabel" name="textLabel1_2" >
-        <property name="text" >
-         <string>Network Key (Repeat)</string>
-        </property>
-        <property name="wordWrap" >
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="2" colspan="3" >
-       <widget class="QLineEdit" name="lineKey2" >
-        <property name="echoMode" >
-         <enum>QLineEdit::Password</enum>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0" >
-       <widget class="QLabel" name="textLabel1_2_2" >
-        <property name="text" >
+      <item row="2" column="0">
+       <widget class="QLabel" name="textLabel1_2_2">
+        <property name="text">
          <string>Key Index</string>
         </property>
-        <property name="wordWrap" >
+        <property name="wordWrap">
          <bool>false</bool>
         </property>
        </widget>
       </item>
-      <item row="3" column="1" colspan="3" >
-       <widget class="QSpinBox" name="spinIndex" >
-        <property name="minimum" >
+      <item row="2" column="1" colspan="3">
+       <widget class="QSpinBox" name="spinIndex">
+        <property name="minimum">
          <number>1</number>
         </property>
-        <property name="maximum" >
+        <property name="maximum">
          <number>4</number>
         </property>
        </widget>
       </item>
-      <item row="3" column="4" >
-       <spacer name="spacer11" >
-        <property name="orientation" >
+      <item row="2" column="4">
+       <spacer name="spacer11">
+        <property name="orientation">
          <enum>Qt::Horizontal</enum>
         </property>
-        <property name="sizeType" >
+        <property name="sizeType">
          <enum>QSizePolicy::Expanding</enum>
         </property>
-        <property name="sizeHint" stdset="0" >
+        <property name="sizeHint" stdset="0">
          <size>
           <width>61</width>
           <height>21</height>
@@ -110,9 +94,9 @@
         </property>
        </spacer>
       </item>
-      <item row="4" column="0" colspan="5" >
-       <widget class="QCheckBox" name="checkShowKey" >
-        <property name="text" >
+      <item row="3" column="0" colspan="5">
+       <widget class="QCheckBox" name="checkShowKey">
+        <property name="text">
          <string>Show Key</string>
         </property>
        </widget>
@@ -120,78 +104,22 @@
      </layout>
     </widget>
    </item>
-   <item row="1" column="0" >
-    <layout class="QHBoxLayout" name="horizontalLayout" >
-     <item>
-      <spacer name="spacer12" >
-       <property name="orientation" >
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeType" >
-        <enum>QSizePolicy::Expanding</enum>
-       </property>
-       <property name="sizeHint" stdset="0" >
-        <size>
-         <width>161</width>
-         <height>21</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QPushButton" name="pushClose" >
-       <property name="text" >
-        <string>&amp;Close</string>
-       </property>
-       <property name="shortcut" >
-        <string>Alt+C</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
+   <item row="1" column="0">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>
- <layoutdefault spacing="6" margin="11" />
+ <layoutdefault spacing="6" margin="11"/>
  <includes>
-  <include location="local" >qmessagebox.h</include>
-  <include location="local" >QGroupBox</include>
+  <include location="local">qmessagebox.h</include>
+  <include location="local">QGroupBox</include>
  </includes>
  <resources>
-  <include location="wificonfig.qrc" />
+  <include location="wificonfig.qrc"/>
  </resources>
- <connections>
-  <connection>
-   <sender>pushClose</sender>
-   <signal>clicked()</signal>
-   <receiver>wepConfig</receiver>
-   <slot>slotClose()</slot>
-   <hints>
-    <hint type="sourcelabel" >
-     <x>20</x>
-     <y>20</y>
-    </hint>
-    <hint type="destinationlabel" >
-     <x>20</x>
-     <y>20</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>checkShowKey</sender>
-   <signal>clicked()</signal>
-   <receiver>wepConfig</receiver>
-   <slot>slotShowKey()</slot>
-   <hints>
-    <hint type="sourcelabel" >
-     <x>170</x>
-     <y>177</y>
-    </hint>
-    <hint type="destinationlabel" >
-     <x>170</x>
-     <y>116</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>

--- a/src/wificonfig/wificonfig.pro
+++ b/src/wificonfig/wificonfig.pro
@@ -5,11 +5,11 @@ CONFIG	+= qt warn_on release
 
 LIBS	+= -L/usr/local/lib -ltrueos-utils -ltrueos-ui
 
-HEADERS	+= dialogwpapersonal.h wepconfig.h wificonfigwidgetbase.h wifiscanssid.h wifiselectiondialog.h
+HEADERS	+= dialogwpaenterprise.h dialogwpapersonal.h wepconfig.h wificonfigwidgetbase.h wifiscanssid.h wifiselectiondialog.h
 
-SOURCES	+= dialogwpapersonal.cpp main.cpp wepconfig.cpp wificonfigwidgetbase.cpp wifiscanssid.cpp wifiselectiondialog.cpp
+SOURCES	+= dialogwpaenterprise.cpp dialogwpapersonal.cpp main.cpp wepconfig.cpp wificonfigwidgetbase.cpp wifiscanssid.cpp wifiselectiondialog.cpp
 
-FORMS += dialogwpapersonal.ui wepconfig.ui wificonfigwidgetbase.ui wifiscanssid.ui wifiselectiondialog.ui
+FORMS += dialogwpaenterprise.ui dialogwpapersonal.ui wepconfig.ui wificonfigwidgetbase.ui wifiscanssid.ui wifiselectiondialog.ui
 
 RESOURCES += wificonfig.qrc
 

--- a/src/wificonfig/wificonfigwidgetbase.cpp
+++ b/src/wificonfig/wificonfigwidgetbase.cpp
@@ -649,35 +649,35 @@ void wificonfigwidgetbase::slotEditProfile()
       if (foundSSID)
       {
           // Set our internal flag that this is an edit on an existing device
-          wifiselect = new wifiselectiondialog();
-          wifiselect->init(DeviceName);
-          wifiselect->setWPAOnly(WPAONLY);
+          wifiselectiondialog wifiselect;
+          wifiselect.init(DeviceName);
+          wifiselect.setWPAOnly(WPAONLY);
 
           // Check the type of SSID this is, and issue appropriate edit 
           if ( SSIDEncType[curItem] == NO_ENCRYPTION) {
-             wifiselect->initEdit(SSIDList[curItem], BSSID[curItem]);
+             wifiselect.initEdit(SSIDList[curItem], BSSID[curItem]);
           }
           if ( SSIDEncType[curItem] == WEP_ENCRYPTION) {
-             wifiselect->initEdit(SSIDList[curItem], BSSID[curItem], WEPKey[curItem], WEPIndex[curItem], WEPHex[curItem]);
+             wifiselect.initEdit(SSIDList[curItem], BSSID[curItem], WEPKey[curItem], WEPIndex[curItem], WEPHex[curItem]);
           }
           if ( SSIDEncType[curItem] == WPA_ENCRYPTION) {
-             wifiselect->initEdit(SSIDList[curItem], BSSID[curItem], WPAPersonalKey[curItem]);
+             wifiselect.initEdit(SSIDList[curItem], BSSID[curItem], WPAPersonalKey[curItem]);
           }
           if ( SSIDEncType[curItem] == WPAE_ENCRYPTION) {
-             wifiselect->initEdit(SSIDList[curItem], BSSID[curItem], WPAEType[curItem], WPAEIdent[curItem], WPAEAnonIdent[curItem], WPAECACert[curItem], WPAEClientCert[curItem], WPAEPrivKeyFile[curItem], WPAEPassword[curItem], WPAEKeyMgmt[curItem], WPAEPhase2[curItem]);
+             wifiselect.initEdit(SSIDList[curItem], BSSID[curItem], WPAEType[curItem], WPAEIdent[curItem], WPAEAnonIdent[curItem], WPAECACert[curItem], WPAEClientCert[curItem], WPAEPrivKeyFile[curItem], WPAEPassword[curItem], WPAEKeyMgmt[curItem], WPAEPhase2[curItem]);
           }
 
 
           // Connect our delete signal, which runs before we add a new SSID
-          connect( wifiselect, SIGNAL( signalDeleteSSID(QString) ), this, SLOT( slotRemoveProfileSSID(QString) ) ); 
+          connect( &wifiselect, SIGNAL( signalDeleteSSID(QString) ), this, SLOT( slotRemoveProfileSSID(QString) ) ); 
 
           // Connect our save signals
-          connect( wifiselect, SIGNAL( signalSavedOpen(QString, bool) ), this, SLOT( slotAddNewProfileOpen(QString, bool) ) );
-          connect( wifiselect, SIGNAL( signalSavedWEP( QString, bool, QString, int, bool ) ), this, SLOT( slotAddNewProfileWEP( QString, bool, QString, int, bool) ) );
-          connect( wifiselect, SIGNAL( signalSavedWPA(QString, bool, QString) ), this, SLOT( slotAddNewProfileWPA(QString, bool, QString) ) );
-          connect( wifiselect, SIGNAL( signalSavedWPAE(QString, bool, int, QString, QString, QString, QString, QString, QString, int, int) ), this, SLOT ( slotAddNewProfileWPAE(QString, bool, int, QString, QString, QString, QString, QString, QString, int, int) ) );
+          connect( &wifiselect, SIGNAL( signalSavedOpen(QString, bool) ), this, SLOT( slotAddNewProfileOpen(QString, bool) ) );
+          connect( &wifiselect, SIGNAL( signalSavedWEP( QString, bool, QString, int, bool ) ), this, SLOT( slotAddNewProfileWEP( QString, bool, QString, int, bool) ) );
+          connect( &wifiselect, SIGNAL( signalSavedWPA(QString, bool, QString) ), this, SLOT( slotAddNewProfileWPA(QString, bool, QString) ) );
+          connect( &wifiselect, SIGNAL( signalSavedWPAE(QString, bool, int, QString, QString, QString, QString, QString, QString, int, int) ), this, SLOT ( slotAddNewProfileWPAE(QString, bool, int, QString, QString, QString, QString, QString, QString, int, int) ) );
 
-          wifiselect->exec();
+          wifiselect.exec();
       }
 
 
@@ -738,13 +738,13 @@ void wificonfigwidgetbase::slotAddNewProfileSSID(QString ssidc){
     if(sec.contains("None")){
       slotAddNewProfileOpen(ssidc,false); //call the function to save the variables (no security settings)
     }else if(sec.contains("WEP")){
-     dialogWEP = new wepConfig();
-     connect( dialogWEP, SIGNAL( saved(QString, int, bool) ), this, SLOT( slotWEPSave(QString, int, bool) ) );
-     dialogWEP->exec();
+     wepConfig dialogWEP;
+     connect( &dialogWEP, SIGNAL( saved(QString, int, bool) ), this, SLOT( slotWEPSave(QString, int, bool) ) );
+     dialogWEP.exec();
     }else if(sec.contains("WPA")){ //both WPA and WPA2 encryption
-     dialogWPA = new dialogWPAPersonal();
-     connect( dialogWPA, SIGNAL( saved(QString) ), this, SLOT( slotWPAPSave(QString) ) );
-     dialogWPA->exec();
+     dialogWPAPersonal dialogWPA;
+     connect( &dialogWPA, SIGNAL( saved(QString) ), this, SLOT( slotWPAPSave(QString) ) );
+     dialogWPA.exec();
     }else{
       //Put error handling here
       slotAddNewProfileOpen(ssidc,false); //call the function to save the variables (no security settings)

--- a/src/wificonfig/wificonfigwidgetbase.h
+++ b/src/wificonfig/wificonfigwidgetbase.h
@@ -99,10 +99,7 @@ private:
     void updateWPASupp();
     QString DeviceName;
     QString Country;
-    
-    dialogWPAPersonal *dialogWPA;
-    wepConfig *dialogWEP;
-    wifiselectiondialog *wifiselect;
+
     QProcess *netifProc;
 
     // Lets define our arrays for the SSID profiles

--- a/src/wificonfig/wifiselectiondialog.cpp
+++ b/src/wificonfig/wifiselectiondialog.cpp
@@ -1,3 +1,6 @@
+#include "wepconfig.h"
+#include "dialogwpapersonal.h"
+#include "dialogwpaenterprise.h"
 #include "wifiselectiondialog.h"
 #include "ui_wifiselectiondialog.h"
 #include <qtextstream.h>
@@ -286,14 +289,14 @@ void wifiselectiondialog::slotConfigWPAP()
 void wifiselectiondialog::slotConfigWPAE()
 {
    // Bring up the WPA-Enterprise config dialog
-    
-   dialogWPAE libWPAE;
-   
+
+   dialogWPAEnterprise libWPAE;
+
    if ( ! WPAEIdent.isEmpty() )
    {
        libWPAE.setVariables(WPAEType, WPAEIdent, WPAEAnonIdent, WPAECACert, WPAEClientCert, WPAEPrivKeyFile, WPAEPassword, WPAEKeyMgmt, WPAEPhase2);
    }
-   
+
    connect( &libWPAE, SIGNAL( saved(int, QString, QString, QString, QString, QString, QString, int, int) ), this, SLOT( slotWPAEChanged(int, QString, QString, QString, QString, QString, QString, int, int) ) );
    libWPAE.exec();
 }

--- a/src/wificonfig/wifiselectiondialog.cpp
+++ b/src/wificonfig/wifiselectiondialog.cpp
@@ -185,15 +185,15 @@ void wifiselectiondialog::initEdit(QString selectedSSID, bool usingBSSID)
 
 void wifiselectiondialog::slotConfigWEP()
 {
-   dialogWEP = new wepConfig();
+   wepConfig dialogWEP;
    
    if ( ! WEPKey.isEmpty() )
    {
-       dialogWEP->setKey(WEPKey, WEPIndex, WEPHex);
+       dialogWEP.setKey(WEPKey, WEPIndex, WEPHex);
    }
    
-   connect( dialogWEP, SIGNAL( saved(QString, int, bool) ), this, SLOT( slotWEPChanged(QString, int, bool) ) ); 
-   dialogWEP->exec();
+   connect( &dialogWEP, SIGNAL( saved(QString, int, bool) ), this, SLOT( slotWEPChanged(QString, int, bool) ) ); 
+   dialogWEP.exec();
 }
 
 
@@ -270,15 +270,15 @@ void wifiselectiondialog::slotConfigWPAP()
 {
     // Bring up the WPA-Personal config dialog
     
-   dialogWPAP = new dialogWPAPersonal();
+   dialogWPAPersonal dialogWPAP;
    
    if ( ! WPAPersonalKey.isEmpty() )
    {
-       dialogWPAP->setKey(WPAPersonalKey);
+       dialogWPAP.setKey(WPAPersonalKey);
    }
    
-   connect( dialogWPAP, SIGNAL( saved(QString) ), this, SLOT( slotWPAPChanged(QString) ) ); 
-   dialogWPAP->exec();
+   connect( &dialogWPAP, SIGNAL( saved(QString) ), this, SLOT( slotWPAPChanged(QString) ) ); 
+   dialogWPAP.exec();
 
 }
 
@@ -287,15 +287,15 @@ void wifiselectiondialog::slotConfigWPAE()
 {
    // Bring up the WPA-Enterprise config dialog
     
-   libWPAE = new dialogWPAE();
+   dialogWPAE libWPAE;
    
    if ( ! WPAEIdent.isEmpty() )
    {
-       libWPAE->setVariables(WPAEType, WPAEIdent, WPAEAnonIdent, WPAECACert, WPAEClientCert, WPAEPrivKeyFile, WPAEPassword, WPAEKeyMgmt, WPAEPhase2);
+       libWPAE.setVariables(WPAEType, WPAEIdent, WPAEAnonIdent, WPAECACert, WPAEClientCert, WPAEPrivKeyFile, WPAEPassword, WPAEKeyMgmt, WPAEPhase2);
    }
    
-   connect( libWPAE, SIGNAL( saved(int, QString, QString, QString, QString, QString, QString, int, int) ), this, SLOT( slotWPAEChanged(int, QString, QString, QString, QString, QString, QString, int, int) ) );
-   libWPAE->exec();
+   connect( &libWPAE, SIGNAL( saved(int, QString, QString, QString, QString, QString, QString, int, int) ), this, SLOT( slotWPAEChanged(int, QString, QString, QString, QString, QString, QString, int, int) ) );
+   libWPAE.exec();
 }
 
 

--- a/src/wificonfig/wifiselectiondialog.h
+++ b/src/wificonfig/wifiselectiondialog.h
@@ -4,12 +4,9 @@
 #include <qfile.h>
 #include <qmessagebox.h>
 #include <qdialog.h>
-#include "wepconfig.h"
-#include "dialogwpapersonal.h"
 #include "wifiscanssid.h"
 #include "ui_wifiselectiondialog.h"
 #include "trueos-utils.h"
-#include "trueos-ui.h"
 
 class wifiselectiondialog : public QDialog, private Ui::wifiselectiondialog
 {

--- a/src/wificonfig/wifiselectiondialog.h
+++ b/src/wificonfig/wifiselectiondialog.h
@@ -53,9 +53,6 @@ private:
 
     // Setup our dialogs
     wifiscanssid *dialogWifiscanssid;
-    wepConfig *dialogWEP;
-    dialogWPAPersonal *dialogWPAP;
-    dialogWPAE *libWPAE;
 
     // WEP variables
     QString WEPKey;


### PR DESCRIPTION
Hello,
I've been using the wifi connection dialogs for a while, but the fact that I have to enter passwords twice is very annoying. I can't think of a good security reason to do this (especially considering other operating systems don't ask for them twice, and the show key checkbox makes the second line edit redundant). Anyone using the GUI is going to be rate limited anyway.
So, I dug into my old Qt hacking skills and removed the second dialog in all the wifi dialogs.
I also made it possible to cancel out of the dialogs. In the current version, if you enter the wifi dialog by accident, you can't just close the dialog. You must enter a password (and a correct one at that). This forgives choosing an incorrect wifi.

While I was there I "modernized" the calling conventions (well, how we designed them back in 2005) and noticed the code was leaking the dialog everytime it was created so I fixed those as well.

WPA Enterprise is currently in libtrueos-ui though I don't know why. I have also moved it into here. (and created a corresponding pull request in libtrueos.
There's also a .gitignore file, because it was annoying to see all the object files when calling git status

I'm sorry if these come through as too many changes in one shot. Each commit builds on the last, so you can stop your rebase where you want.